### PR TITLE
:memo: Add contribution guide to the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contribute Code or Provide Feedback
+
+If you would like to become an active contributor to this project please follow the instructions provided in [Microsoft Azure Projects Contribution Guidelines](http://azure.github.io/guidelines/).
+
+If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/adrianhall/generator-azure-mobile-apps/issues) section of the project.


### PR DESCRIPTION
This commits adds a scheleton project contribution guide based on
Azure projects contrubution guidelines.

The purpose of this file:
https://git.io/vWzPt

Thanks!
