### PR TITLE
:bug: Remove duplicate ESLint rules

### DIFF
--- a/app/templates/_eslintrc.js
+++ b/app/templates/_eslintrc.js
@@ -49,8 +49,6 @@ module.exports = exports = {
         "no-extend-native": ERROR,
         "no-extra-bind": WARN,
         "no-extra-parens": ERROR,
-        "no-extend-native": ERROR,
-        "no-extra-bind": WARN,
         "no-floating-decimal": WARN,
         "no-implicit-coercion": [ WARN, {
             "boolean": true,


### PR DESCRIPTION
ESLint/JShint warnings :)

```
         "no-extend-native": ERROR,
         "no-extra-bind": WARN,
         [..]
-        "no-extend-native": ERROR,
-        "no-extra-bind": WARN,
```

Thanks!
