### PR TITLE
:fire: Remove unused dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/adrianhall/generator-azure-mobile-apps.git"
-  },
-  "devDependencies": {
-    "gulp": "^3.9.0",
-    "gulp-eslint": "^1.1.1",
-    "gulp-mocha": "^2.2.0"
   }
 }


### PR DESCRIPTION
It seems that Gulp is no longer used to develop the project.
Assuming that linting role can be easily done by supported IDE
editors this commit removes Gulp, Gulp plugins dev dependencies
as not required

Thanks!
